### PR TITLE
feat: migrate authentication to OAuth 2.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,29 +8,32 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## アーキテクチャ
 
-- Docker Composeで2つのコンテナを起動
+- Docker Composeで3つのコンテナを起動
+  - **認可サーバー**（コンテナ名: `auth`）
+    - Node.js 24ランタイム
+    - エントリーポイント: `server.js`
+    - OAuth 2.1クライアントクレデンシャルズフローを提供 (`/token`, `/jwks.json`, `/.well-known/openid-configuration`)
+    - 起動時にRSA鍵ペアを生成し、JWKSで公開鍵を配布
+    - `CLIENT_ID` / `CLIENT_SECRET` / `ALLOWED_SCOPES`などを環境変数で設定
   - **mcpサーバー**（コンテナ名: `mcp`）
     - Node.js 24ランタイム
     - エントリーポイント: `server.js`
-    - WebsocketによるMCPクライアント・サーバー間通信
+    - WebSocketによるMCPクライアント・サーバー間通信
     - ポート3000で待ち受け
     - ボリュームマウント:
       - `./data` → `/data` (ファイル操作対象)
       - `./server` → `/app` (開発用、ホットリロード可能)
-    - コンテナ起動時に自動的に`npm install`を実行
     - `TARGET_DIR`環境変数で操作対象ディレクトリを指定（デフォルト: `/data`）
-    - `API_KEY`環境変数で認証を有効化（未設定時は認証無効）
+    - OAuth 2.1 Bearerトークンを検証（issuer / audience / scope）
     - 提供ツール: `list-files`, `read-file`
-    - **認証機能**: WebSocketハンドシェイク時にAPIキーを検証
   - **mcpクライアント**（コンテナ名: `mcp-client`）
     - Node.js 24ランタイム
     - エントリーポイント: `client.js`
-    - WebSocketでサーバーに接続
+    - 起動時に`/token`へアクセスしてBearerトークンを取得
+    - WebSocket接続時に`Authorization: Bearer ...`ヘッダーを付与
     - ボリュームマウント:
       - `./client` → `/app` (開発用、ホットリロード可能)
-    - コンテナ起動時に自動的に`npm install`を実行
-    - `API_KEY`環境変数を`X-API-Key`ヘッダーでサーバーに送信
-- 両コンテナは`mcp-network`で接続
+- 3つのコンテナは`mcp-network`で接続
 - ES Modules使用（package.jsonに`"type": "module"`を設定）
 - node_modules/は.gitignoreで管理外
 
@@ -38,6 +41,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```
 .
+├── auth/                # OAuth 2.1認可サーバー
+│   ├── server.js        # エントリーポイント
+│   ├── package.json     # npm依存関係
+│   └── Dockerfile       # コンテナ定義
 ├── server/              # MCPサーバー
 │   ├── server.js        # エントリーポイント
 │   ├── package.json     # npm依存関係
@@ -65,14 +72,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # コンテナビルド
 docker compose build
 
-# サーバーコンテナ起動（自動的にnpm installが実行される）
-API_KEY="your-secret-key" docker compose up mcp -d
+# 認可サーバーとMCPサーバーを起動（自動的にnpm installが実行される）
+export OAUTH_CLIENT_ID="mcp-client"
+export OAUTH_CLIENT_SECRET="replace-with-strong-secret"
+docker compose up mcp -d
 
 # サーバーログ確認
 docker compose logs mcp --tail 20
 
 # クライアント実行（自動的にnpm installが実行される）
-API_KEY="your-secret-key" docker compose run --rm mcp-client
+export OAUTH_CLIENT_ID="mcp-client"
+export OAUTH_CLIENT_SECRET="replace-with-strong-secret"
+docker compose run --rm --no-deps mcp-client
 
 # コンテナ停止
 docker compose down
@@ -86,17 +97,21 @@ docker compose restart mcp
 
 **認証のテスト:**
 ```bash
-# サーバー起動
-API_KEY="test-key-123" docker compose up mcp -d
+# 正しいクライアント資格情報でトークン取得＆接続（成功）
+OAUTH_CLIENT_ID="mcp-client" \
+OAUTH_CLIENT_SECRET="replace-with-strong-secret" \
+docker compose run --rm --no-deps mcp-client
 
-# 正しいAPIキーでクライアント実行（成功）
-API_KEY="test-key-123" docker compose run --rm --no-deps mcp-client
+# 誤ったクライアントシークレット（401エラー）
+OAUTH_CLIENT_ID="mcp-client" \
+OAUTH_CLIENT_SECRET="wrong-secret" \
+docker compose run --rm --no-deps mcp-client
 
-# 間違ったAPIキーでクライアント実行（401エラー）
-API_KEY="wrong-key" docker compose run --rm --no-deps mcp-client
-
-# APIキーなしでクライアント実行（401エラー）
-API_KEY="" docker compose run --rm --no-deps mcp-client
+# スコープ不足（OAUTH_SCOPEを変更して401エラーを確認）
+OAUTH_CLIENT_ID="mcp-client" \
+OAUTH_CLIENT_SECRET="replace-with-strong-secret" \
+OAUTH_SCOPE="file.read" \
+docker compose run --rm --no-deps mcp-client
 ```
 
 **開発時の注意点:**
@@ -142,45 +157,33 @@ API_KEY="" docker compose run --rm --no-deps mcp-client
 
 ### 認証の実装
 
-- **サーバー側** (`server/server.js:18-39`):
-  - `WebSocketServer`の`verifyClient`コールバックで認証
-  - `X-API-Key`ヘッダーまたはクエリパラメータ`api_key`を検証
-  - 認証失敗時は`401 Unauthorized`を返す
-  - `API_KEY`環境変数が未設定の場合は警告を表示して認証を無効化
+- **サーバー側** (`server/server.js:10-88`):
+  - WebSocketハンドシェイク時に`Authorization: Bearer <token>`ヘッダーを必須とし、`jwtVerify`でissuer / audience / scopeを検証。
+  - 必須スコープは`OAUTH_REQUIRED_SCOPES`で制御。
+  - 認証失敗時は`401 Unauthorized`を返し、成功時は`req.authContext`にJWTペイロードを格納。
 
-- **クライアント側** (`client/client.js:10-14`):
-  - WebSocket接続時に`X-API-Key`ヘッダーでAPIキーを送信
-  - 環境変数`API_KEY`から取得
+- **クライアント側** (`client/client.js:3-143`):
+  - 起動時に`OAUTH_TOKEN_URL`へクライアントクレデンシャルズリクエストを送り、アクセストークンを取得。
+  - 既存トークンを使用する場合は`OAUTH_ACCESS_TOKEN`を参照し、WebSocket接続時にBearerトークンを付与。
+
+- **認可サーバー側** (`auth/server.js:5-121`):
+  - 起動時にRSA鍵を生成し、JWKSとOpenID Provider Metadataを公開。
+  - `/token`エンドポイントで`client_secret_basic`もしくは`client_secret_post`によるクライアント認証を行い、JWTアクセストークンを発行。
+  - 要求スコープを検証し、失敗時は`invalid_scope`エラーを返却。
 
 ### セキュリティのベストプラクティス
 
-1. **強力なAPIキーの生成**:
-   ```bash
-   openssl rand -hex 32
-   ```
-
-2. **環境変数ファイル（`.env`）の使用**:
-   ```bash
-   # .env ファイル（gitで管理しない）
-   API_KEY=your-generated-secret-key-here
-   ```
-
-3. **本番環境ではWSS（WebSocket Secure）を使用**:
-   - リバースプロキシ（Nginx, Traefik等）でTLS終端
-   - Let's Encryptで証明書を取得
-
-4. **将来の拡張**:
-   - OAuth 2.1への移行（MCP公式仕様に準拠）
-   - JWT認証の実装
-   - レート制限の追加
-   - 監査ログの記録
+1. **強力なクライアントシークレットを生成**: `openssl rand -hex 32`などで十分に長い乱数を作成し、`.env`やシークレットマネージャーで保管。
+2. **最小権限のスコープ設計**: サーバーで必要なスコープのみを`OAUTH_REQUIRED_SCOPES`に設定する。
+3. **TLS終端の導入**: 本番環境では`wss://`経由で接続し、リバースプロキシでTLS証明書を管理。
+4. **資格情報/鍵のローテーション**: `CLIENT_SECRET`やRSA鍵を定期的に更新し、複数の`kid`対応やキーイングストラテジー拡張を検討。
 
 ## トラブルシューティング
 
 - サーバーが起動しない場合: `docker compose logs mcp` でログを確認
 - クライアントが接続できない場合（401エラー）:
-  - `docker compose logs mcp | grep -i auth` で認証ログを確認
-  - サーバーとクライアントで同じ`API_KEY`を使用しているか確認
+  - `docker compose logs auth --tail 20` と `docker compose logs mcp --tail 20` で詳細を確認
+  - `OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` が一致しているか確認
+  - 発行されたトークンのスコープに`file.read`と`file.list`が含まれているか確認
 - クライアントが接続できない場合（その他）: サーバーが起動しているか確認 (`docker compose ps`)
 - 依存関係のエラーが出る場合: コンテナを再起動（`docker compose restart mcp`）すると自動的に`npm install`が実行されます
-

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ WebSocketを使用したModel Context Protocol (MCP)のサンプル実装です�
 - **MCPサーバー**: WebSocketでMCPプロトコルを実装
   - `list-files`: ディレクトリ内のファイル一覧を取得
   - `read-file`: ファイルの内容を読み込み
-  - **APIキー認証**: X-API-Keyヘッダーによる認証機能
+  - **OAuth 2.1認証**: クライアントクレデンシャルズフローによるBearerトークン検証
 - **MCPクライアント**: サーバーに接続してツールを実行
 - **Docker Compose**: サーバーとクライアントをコンテナ化
 
@@ -34,18 +34,18 @@ docker compose build
 
 ## 使い方
 
-### サーバーの起動
+### サーバーと認可サーバーの起動
 
 ```bash
-# APIキーを指定してサーバーを起動
-API_KEY="your-secret-key" docker compose up mcp -d
-
-# または環境変数をエクスポート
-export API_KEY="your-secret-key"
+# 必要に応じてクライアント資格情報を上書き
+export OAUTH_CLIENT_ID="mcp-client"
+export OAUTH_CLIENT_SECRET="replace-with-strong-secret"
 docker compose up mcp -d
 ```
 
-> **注意**: 本番環境では必ず強力なAPIキーを設定してください。APIキーが未設定の場合、認証が無効化され、警告が表示されます。
+`mcp`サービスを起動すると依存関係としてOAuth 2.1認可サーバー（`auth`）も自動的に立ち上がり、`mcp`サーバーはJWKSを用いてBearerトークンを検証します。
+
+> **注意**: サンプルのデフォルト資格情報（`mcp-client` / `mcp-client-secret`）は開発用途のみです。本番環境では必ず強固なシークレットに置き換えてください。
 
 ### サーバーログの確認
 
@@ -56,21 +56,19 @@ docker compose logs mcp --tail 20
 ### クライアントの実行
 
 ```bash
-# サーバーと同じAPIキーを指定
-API_KEY="your-secret-key" docker compose run --rm mcp-client
-
-# または環境変数を使用
-export API_KEY="your-secret-key"
-docker compose run --rm mcp-client
+# サーバー起動時に使用した資格情報を共有
+export OAUTH_CLIENT_ID="mcp-client"
+export OAUTH_CLIENT_SECRET="replace-with-strong-secret"
+docker compose run --rm --no-deps mcp-client
 ```
 
 クライアントは以下のテストを実行します：
-1. サーバーへの接続と初期化（APIキー認証）
+1. サーバーへの接続と初期化（OAuth 2.1 認証）
 2. ルートディレクトリのファイル一覧取得
 3. sample1.txtの読み込み
 4. sample2.txtの読み込み
 
-> **注意**: クライアントとサーバーで同じAPIキーを使用する必要があります。APIキーが一致しない場合、`401 Unauthorized`エラーが返されます。
+> **ヒント**: 既存のトークンを直接指定したい場合は、`OAUTH_ACCESS_TOKEN`環境変数にBearerトークンをセットするとクライアントはトークンエンドポイントへのアクセスを省略します。
 
 ### サーバーの停止
 
@@ -81,22 +79,34 @@ docker compose down
 ## アーキテクチャ
 
 ```
-┌─────────────────┐         WebSocket         ┌─────────────────┐
-│   MCP Client    │ ◄────────────────────────► │   MCP Server    │
-│  (Node.js 24)   │     ws://mcp:3000          │  (Node.js 24)   │
-└─────────────────┘                            └─────────────────┘
-                                                        │
-                                                        ▼
-                                                  ┌──────────┐
-                                                  │  /data   │
-                                                  │ (volume) │
-                                                  └──────────┘
+┌─────────────────┐      Token Request      ┌────────────────────────┐
+│   MCP Client    │ ───────────────────────►│  OAuth 2.1 Auth Server │
+│  (Node.js 24)   │◄─────────────────────── │   (client credentials) │
+└─────────────────┘   Bearer Token (JWT)    └────────────────────────┘
+          │                                             │
+          │ WebSocket (Bearer Token)                    │ JWKS
+          ▼                                             ▼
+┌─────────────────┐◄────────────────────────────────────┘
+│   MCP Server    │            Key Validation
+│  (Node.js 24)   │
+└─────────────────┘
+          │
+          │ File Access
+          ▼
+┌─────────────────┐
+│     /data       │
+│   (volume)      │
+└─────────────────┘
 ```
 
 ### ディレクトリ構成
 
 ```
 .
+├── auth/                # OAuth 2.1認可サーバー
+│   ├── server.js
+│   ├── package.json
+│   └── Dockerfile
 ├── server/              # MCPサーバー
 │   ├── server.js        # WebSocketサーバー実装
 │   ├── manifest.json    # MCPツール定義
@@ -119,12 +129,29 @@ docker compose down
 
 - `PORT`: WebSocketサーバーのポート（デフォルト: 3000）
 - `TARGET_DIR`: ファイル操作の対象ディレクトリ（デフォルト: /data）
-- `API_KEY`: 認証用のAPIキー（**必須推奨**。未設定の場合は認証が無効化されます）
+- `OAUTH_ISSUER`: トークン発行者のURL（例: http://auth:8080）
+- `OAUTH_JWKS_URL`: JWKSエンドポイント（例: http://auth:8080/jwks.json）
+- `OAUTH_AUDIENCE`: 検証対象となるaudクレーム（デフォルト: mcp-server）
+- `OAUTH_REQUIRED_SCOPES`: 必須スコープをスペース区切りで列挙
 
 ### クライアント (mcp-client)
 
 - `SERVER_URL`: MCPサーバーのWebSocket URL（デフォルト: ws://mcp:3000）
-- `API_KEY`: サーバー接続用のAPIキー（サーバーと同じ値を設定）
+- `OAUTH_TOKEN_URL`: トークンエンドポイント（例: http://auth:8080/token）
+- `OAUTH_CLIENT_ID`: クライアントID
+- `OAUTH_CLIENT_SECRET`: クライアントシークレット
+- `OAUTH_SCOPE`: 要求するスコープ（デフォルト: file.read file.list）
+- `OAUTH_ACCESS_TOKEN`: 既存のアクセストークン（任意。指定時はトークンエンドポイントへアクセスしません）
+
+### 認可サーバー (auth)
+
+- `PORT`: 認可サーバーの待受ポート（デフォルト: 8080）
+- `CLIENT_ID`: 許可するクライアントID
+- `CLIENT_SECRET`: クライアントシークレット
+- `ISSUER`: 発行者識別子（例: http://auth:8080）
+- `AUDIENCE`: アクセストークンに設定するaudクレーム
+- `ALLOWED_SCOPES`: 許可するスコープ一覧（スペース区切り）
+- `TOKEN_TTL`: アクセストークンの有効期限（秒、デフォルト: 300）
 
 ## 開発
 
@@ -208,34 +235,27 @@ docker compose exec mcp sh
 
 ### 認証
 
-このサンプルはAPIキー認証を実装しています：
+このサンプルはOAuth 2.1のクライアントクレデンシャルズフローを実装しています：
 
-- **ヘッダー認証**: クライアントは`X-API-Key`ヘッダーでAPIキーを送信
-- **検証**: サーバーはWebSocketハンドシェイク時に認証を実行
-- **エラー処理**: 認証失敗時は`401 Unauthorized`を返す
+- **トークン取得**: クライアントは`auth`サービスの`/token`エンドポイントに対してBasic認証でリクエストを送り、アクセストークン（JWT）を取得します。
+- **鍵配布**: 認可サーバーは起動時にRSA鍵ペアを生成し、`/jwks.json`で公開鍵を配布します。オプションでOpenID Provider Metadata (`/.well-known/openid-configuration`) も提供します。
+- **トークン検証**: `mcp`サーバーはWebSocketハンドシェイク時にBearerトークンを受け取り、issuer / audience / scope を検証します。不正なトークンの場合は`401 Unauthorized`を返します。
 
 ### セキュリティのベストプラクティス
 
-1. **強力なAPIキーを使用**: 推測困難なランダムな文字列を生成
-   ```bash
-   # 例: opensslで生成
-   openssl rand -hex 32
-   ```
-
-2. **環境変数で管理**: APIキーをコードに直接書き込まない
-
+1. **強力なクライアントシークレットを使用**: 推測困難なランダム文字列を生成し、資格情報ストアやシークレットマネージャーで安全に保管します。
+2. **スコープは最小限に**: 必要な権限だけを`OAUTH_SCOPE`および`OAUTH_REQUIRED_SCOPES`に設定し、不要なアクセスを避けます。
 3. **本番環境ではHTTPS/WSSを使用**:
    - 現在の実装は`ws://`（非暗号化）
    - 本番環境ではリバースプロキシ（Nginx, Traefik等）でTLS終端を実装
-
-4. **APIキーのローテーション**: 定期的にAPIキーを変更
+4. **資格情報と鍵のローテーション**: クライアントシークレットや署名鍵を定期的に更新し、必要に応じて複数のJWKSキーを配布する実装に拡張します。
 
 ### 将来の拡張
 
-- OAuth 2.1対応
-- JWT（JSON Web Token）認証
-- レート制限
-- アクセスログの記録
+- Authorization Code + PKCE フローの追加
+- Refresh Token / Token Revocation 対応
+- レート制限とアノマリ検知
+- セキュリティ監査ログの外部ストレージ出力
 
 ## トラブルシューティング
 
@@ -247,14 +267,20 @@ docker compose logs mcp
 
 ### クライアントが接続できない（401 Unauthorized）
 
-APIキーが一致しているか確認：
-```bash
-# サーバーのログを確認
-docker compose logs mcp | grep -i auth
-
-# 同じAPIキーを使用しているか確認
-echo $API_KEY
-```
+- 認可サーバーとMCPサーバーのログで詳細を確認：
+  ```bash
+  docker compose logs auth --tail 20
+  docker compose logs mcp --tail 20
+  ```
+- `OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` が一致しているか確認：
+  ```bash
+  echo $OAUTH_CLIENT_ID
+  echo $OAUTH_CLIENT_SECRET
+  ```
+- 発行されたトークンのスコープに`file.read`や`file.list`が含まれているか確認：
+  ```bash
+  docker compose logs auth | grep scope
+  ```
 
 ### クライアントが接続できない（その他）
 

--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:24
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install --production
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["npm", "start"]

--- a/auth/package.json
+++ b/auth/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test"
   },
   "dependencies": {
     "express": "^4.19.2",

--- a/auth/package.json
+++ b/auth/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mcp-auth-server",
+  "version": "1.0.0",
+  "description": "Sample OAuth 2.1 authorization server for MCP demo",
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "jose": "^5.3.0"
+  }
+}

--- a/auth/server.js
+++ b/auth/server.js
@@ -1,0 +1,121 @@
+import express from 'express';
+import { createHash } from 'crypto';
+import { generateKeyPair, exportJWK, SignJWT } from 'jose';
+
+const PORT = Number(process.env.PORT) || 8080;
+const CLIENT_ID = process.env.CLIENT_ID || 'mcp-client';
+const CLIENT_SECRET = process.env.CLIENT_SECRET || 'mcp-client-secret';
+const ISSUER = process.env.ISSUER || `http://localhost:${PORT}`;
+const AUDIENCE = process.env.AUDIENCE || 'mcp-server';
+const ALLOWED_SCOPES = (process.env.ALLOWED_SCOPES || 'file.read file.list')
+  .split(/\s+/)
+  .filter(Boolean);
+const TOKEN_TTL = Number(process.env.TOKEN_TTL) || 300;
+
+const app = express();
+app.use(express.urlencoded({ extended: false }));
+app.use(express.json());
+
+const { publicKey, privateKey } = await generateKeyPair('RS256', { modulusLength: 2048 });
+const jwk = await exportJWK(publicKey);
+jwk.kid = createHash('sha256')
+  .update(JSON.stringify(jwk))
+  .digest('hex')
+  .slice(0, 16);
+jwk.use = 'sig';
+jwk.alg = 'RS256';
+
+const JWKS_RESPONSE = { keys: [jwk] };
+
+function validateClient(authorizationHeader, bodyClientId, bodyClientSecret) {
+  if (authorizationHeader?.startsWith('Basic ')) {
+    const credentials = Buffer.from(authorizationHeader.replace(/^Basic\s+/i, ''), 'base64').toString('utf-8');
+    const separatorIndex = credentials.indexOf(':');
+    if (separatorIndex === -1) {
+      return false;
+    }
+
+    const clientId = credentials.slice(0, separatorIndex);
+    const clientSecret = credentials.slice(separatorIndex + 1);
+    return clientId === CLIENT_ID && clientSecret === CLIENT_SECRET;
+  }
+
+  if (bodyClientId && bodyClientSecret) {
+    return bodyClientId === CLIENT_ID && bodyClientSecret === CLIENT_SECRET;
+  }
+
+  return false;
+}
+
+app.get('/.well-known/openid-configuration', (req, res) => {
+  res.json({
+    issuer: ISSUER,
+    token_endpoint: `${ISSUER}/token`,
+    jwks_uri: `${ISSUER}/jwks.json`,
+    grant_types_supported: ['client_credentials'],
+    token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post'],
+    scopes_supported: ALLOWED_SCOPES
+  });
+});
+
+app.get('/jwks.json', (req, res) => {
+  res.json(JWKS_RESPONSE);
+});
+
+app.get('/healthz', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.post('/token', async (req, res) => {
+  if (!validateClient(req.headers.authorization, req.body.client_id, req.body.client_secret)) {
+    return res.status(401).json({
+      error: 'invalid_client',
+      error_description: 'Client authentication failed'
+    });
+  }
+
+  const grantType = req.body.grant_type;
+  if (grantType !== 'client_credentials') {
+    return res.status(400).json({
+      error: 'unsupported_grant_type',
+      error_description: 'Only client_credentials grant is supported'
+    });
+  }
+
+  const scopeString = req.body.scope || ALLOWED_SCOPES.join(' ');
+  const requestedScopes = scopeString.split(/\s+/).filter(Boolean);
+  const invalidScopes = requestedScopes.filter(scope => !ALLOWED_SCOPES.includes(scope));
+
+  if (invalidScopes.length > 0) {
+    return res.status(400).json({
+      error: 'invalid_scope',
+      error_description: `Unsupported scopes requested: ${invalidScopes.join(', ')}`
+    });
+  }
+
+  const accessToken = await new SignJWT({
+    scope: requestedScopes.join(' ')
+  })
+    .setProtectedHeader({ alg: 'RS256', kid: jwk.kid })
+    .setIssuer(ISSUER)
+    .setAudience(AUDIENCE)
+    .setSubject(CLIENT_ID)
+    .setIssuedAt()
+    .setExpirationTime(`${TOKEN_TTL}s`)
+    .sign(privateKey);
+
+  res.json({
+    access_token: accessToken,
+    token_type: 'Bearer',
+    expires_in: TOKEN_TTL,
+    scope: requestedScopes.join(' ')
+  });
+});
+
+app.listen(PORT, () => {
+  console.log('OAuth 2.1 authorization server ready');
+  console.log(`  Issuer: ${ISSUER}`);
+  console.log(`  Audience: ${AUDIENCE}`);
+  console.log(`  Allowed scopes: ${ALLOWED_SCOPES.join(', ')}`);
+  console.log(`  Client credentials: ${CLIENT_ID}/${CLIENT_SECRET ? '[set]' : '[missing]'}`);
+});

--- a/auth/tests/auth.test.js
+++ b/auth/tests/auth.test.js
@@ -1,0 +1,227 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { once } from 'node:events';
+import path from 'node:path';
+import net from 'node:net';
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+
+let authProcess;
+let authPort;
+const CLIENT_ID = 'test-client';
+const CLIENT_SECRET = 'super-secret';
+const AUDIENCE = 'test-audience';
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+    server.on('error', reject);
+  });
+}
+
+async function waitForReady(proc, matcher, description) {
+  let output = '';
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(
+          `Timed out waiting for ${description}. Output so far:\n${output}`
+        )
+      );
+    }, 5000);
+
+    const onData = (chunk) => {
+      output += chunk.toString();
+      if (matcher.test(output)) {
+        cleanup();
+        resolve();
+      }
+    };
+
+    const onExit = (code) => {
+      cleanup();
+      reject(
+        new Error(
+          `${description} process exited prematurely` + (code !== null ? ` (code ${code})` : '')
+        )
+      );
+    };
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      proc.stdout?.off('data', onData);
+      proc.stderr?.off('data', onData);
+      proc.off('exit', onExit);
+    };
+
+    proc.on('exit', onExit);
+    proc.stdout?.on('data', onData);
+    proc.stderr?.on('data', onData);
+  });
+}
+
+async function startAuthServer() {
+  authPort = await getFreePort();
+  authProcess = spawn(
+    process.execPath,
+    ['server.js'],
+    {
+      cwd: projectRoot,
+      env: {
+        ...process.env,
+        PORT: String(authPort),
+        CLIENT_ID,
+        CLIENT_SECRET,
+        ISSUER: `http://localhost:${authPort}`,
+        AUDIENCE,
+        ALLOWED_SCOPES: 'file.read file.list',
+        TOKEN_TTL: '120'
+      },
+      stdio: ['ignore', 'pipe', 'pipe']
+    }
+  );
+
+  await waitForReady(
+    authProcess,
+    /authorization server ready/i,
+    'authorization server'
+  );
+}
+
+async function stopAuthServer() {
+  if (!authProcess) {
+    return;
+  }
+  authProcess.kill('SIGTERM');
+  await once(authProcess, 'exit');
+  authProcess = undefined;
+}
+
+async function fetchJson(url, init) {
+  const response = await fetch(url, init);
+  const text = await response.text();
+  let body;
+  try {
+    body = text ? JSON.parse(text) : undefined;
+  } catch (error) {
+    throw new Error(`Failed to parse JSON response (${response.status}): ${text}`);
+  }
+  return { response, body };
+}
+
+test.before(async () => {
+  await startAuthServer();
+});
+
+test.after(async () => {
+  await stopAuthServer();
+});
+
+test('authorization server exposes metadata and issues JWT access tokens', async (t) => {
+  await t.test('health endpoint', async () => {
+    const { response, body } = await fetchJson(`http://localhost:${authPort}/healthz`);
+    assert.strictEqual(response.status, 200);
+    assert.deepStrictEqual(body, { status: 'ok' });
+  });
+
+  await t.test('openid configuration', async () => {
+    const { response, body } = await fetchJson(`http://localhost:${authPort}/.well-known/openid-configuration`);
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(body.issuer, `http://localhost:${authPort}`);
+    assert.strictEqual(body.token_endpoint, `http://localhost:${authPort}/token`);
+    assert.strictEqual(body.jwks_uri, `http://localhost:${authPort}/jwks.json`);
+    assert.deepStrictEqual(body.grant_types_supported, ['client_credentials']);
+  });
+
+  await t.test('token issuance with client credentials', async () => {
+    const basic = Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString('base64');
+    const form = new URLSearchParams({
+      grant_type: 'client_credentials',
+      scope: 'file.read file.list'
+    });
+
+    const { response, body } = await fetchJson(
+      `http://localhost:${authPort}/token`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${basic}`
+        },
+        body: form,
+        redirect: 'manual'
+      }
+    );
+
+    assert.strictEqual(response.status, 200);
+    assert.ok(body.access_token, 'access_token should be present');
+    assert.strictEqual(body.token_type, 'Bearer');
+    assert.strictEqual(body.scope, 'file.read file.list');
+
+    const jwks = createRemoteJWKSet(new URL(`http://localhost:${authPort}/jwks.json`));
+    const { payload, protectedHeader } = await jwtVerify(body.access_token, jwks, {
+      issuer: `http://localhost:${authPort}`,
+      audience: AUDIENCE
+    });
+
+    assert.strictEqual(payload.sub, CLIENT_ID);
+    assert.strictEqual(payload.scope, 'file.read file.list');
+    assert.strictEqual(protectedHeader.alg, 'RS256');
+  });
+
+  await t.test('invalid client secret returns 401', async () => {
+    const basic = Buffer.from(`${CLIENT_ID}:wrong-secret`).toString('base64');
+    const form = new URLSearchParams({
+      grant_type: 'client_credentials'
+    });
+
+    const { response, body } = await fetchJson(
+      `http://localhost:${authPort}/token`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${basic}`
+        },
+        body: form
+      }
+    );
+
+    assert.strictEqual(response.status, 401);
+    assert.strictEqual(body.error, 'invalid_client');
+  });
+
+  await t.test('unsupported scope is rejected', async () => {
+    const basic = Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString('base64');
+    const form = new URLSearchParams({
+      grant_type: 'client_credentials',
+      scope: 'unknown.scope'
+    });
+
+    const { response, body } = await fetchJson(
+      `http://localhost:${authPort}/token`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${basic}`
+        },
+        body: form
+      }
+    );
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(body.error, 'invalid_scope');
+  });
+});

--- a/client/client.js
+++ b/client/client.js
@@ -1,19 +1,58 @@
 import WebSocket from 'ws';
 
 const SERVER_URL = process.env.SERVER_URL || 'ws://localhost:3000';
-const API_KEY = process.env.API_KEY;
+const TOKEN_URL = process.env.OAUTH_TOKEN_URL;
+const CLIENT_ID = process.env.OAUTH_CLIENT_ID;
+const CLIENT_SECRET = process.env.OAUTH_CLIENT_SECRET;
+const REQUESTED_SCOPE = process.env.OAUTH_SCOPE || 'file.read file.list';
+const PRESET_ACCESS_TOKEN = process.env.OAUTH_ACCESS_TOKEN;
 
-console.log(`Connecting to MCP server at ${SERVER_URL}...`);
-console.log(`Authentication: ${API_KEY ? 'enabled' : 'disabled'}`);
-
-// Create WebSocket with API key in headers
-const ws = new WebSocket(SERVER_URL, {
-  headers: {
-    'X-API-Key': API_KEY || ''
-  }
-});
-
+let ws;
 let messageId = 0;
+
+async function getAccessToken() {
+  if (PRESET_ACCESS_TOKEN) {
+    console.log('Using pre-configured OAuth access token from environment');
+    return PRESET_ACCESS_TOKEN;
+  }
+
+  if (!TOKEN_URL) {
+    throw new Error('OAUTH_TOKEN_URL must be set when OAUTH_ACCESS_TOKEN is not provided');
+  }
+
+  if (!CLIENT_ID || !CLIENT_SECRET) {
+    throw new Error('OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET must be configured to request a token');
+  }
+
+  console.log(`Requesting OAuth access token from ${TOKEN_URL} (client_id=${CLIENT_ID})`);
+
+  const body = new URLSearchParams({
+    grant_type: 'client_credentials',
+    scope: REQUESTED_SCOPE
+  });
+
+  const response = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString('base64')}`
+    },
+    body
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Failed to obtain access token (${response.status}): ${errorText}`);
+  }
+
+  const tokenResponse = await response.json();
+  if (!tokenResponse.access_token) {
+    throw new Error('Token response did not include an access_token');
+  }
+
+  console.log('Successfully obtained OAuth access token via client credentials flow');
+  return tokenResponse.access_token;
+}
 
 function sendMessage(message) {
   const id = ++messageId;
@@ -24,68 +63,86 @@ function sendMessage(message) {
   return id;
 }
 
-ws.on('open', async () => {
-  console.log('Connected to MCP server\n');
+async function start() {
+  console.log(`Connecting to MCP server at ${SERVER_URL}...`);
+  console.log('Authentication: OAuth 2.1 (Bearer token)');
 
-  // Initialize
-  sendMessage({ type: 'initialize' });
+  const accessToken = await getAccessToken();
 
-  // Wait a bit for initialization
-  await new Promise(resolve => setTimeout(resolve, 500));
-
-  // Test 1: List files in root directory
-  console.log('\n=== Test 1: List files in root directory ===');
-  sendMessage({
-    type: 'tool_call',
-    name: 'list-files',
-    arguments: {
-      directory: '.'
+  ws = new WebSocket(SERVER_URL, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`
     }
   });
 
-  await new Promise(resolve => setTimeout(resolve, 500));
+  ws.on('open', async () => {
+    console.log('Connected to MCP server\n');
 
-  // Test 2: Read sample1.txt
-  console.log('\n=== Test 2: Read sample1.txt ===');
-  sendMessage({
-    type: 'tool_call',
-    name: 'read-file',
-    arguments: {
-      filePath: 'sample1.txt'
-    }
+    // Initialize
+    sendMessage({ type: 'initialize' });
+
+    // Wait a bit for initialization
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    // Test 1: List files in root directory
+    console.log('\n=== Test 1: List files in root directory ===');
+    sendMessage({
+      type: 'tool_call',
+      name: 'list-files',
+      arguments: {
+        directory: '.'
+      }
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    // Test 2: Read sample1.txt
+    console.log('\n=== Test 2: Read sample1.txt ===');
+    sendMessage({
+      type: 'tool_call',
+      name: 'read-file',
+      arguments: {
+        filePath: 'sample1.txt'
+      }
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    // Test 3: Read sample2.txt
+    console.log('\n=== Test 3: Read sample2.txt ===');
+    sendMessage({
+      type: 'tool_call',
+      name: 'read-file',
+      arguments: {
+        filePath: 'sample2.txt'
+      }
+    });
+
+    // Close connection after tests
+    setTimeout(() => {
+      console.log('\n\nAll tests completed. Closing connection...');
+      ws.close();
+    }, 1500);
   });
 
-  await new Promise(resolve => setTimeout(resolve, 500));
-
-  // Test 3: Read sample2.txt
-  console.log('\n=== Test 3: Read sample2.txt ===');
-  sendMessage({
-    type: 'tool_call',
-    name: 'read-file',
-    arguments: {
-      filePath: 'sample2.txt'
-    }
+  ws.on('message', (data) => {
+    const message = JSON.parse(data.toString());
+    console.log('\n--- Received response ---');
+    console.log(JSON.stringify(message, null, 2));
   });
 
-  // Close connection after tests
-  setTimeout(() => {
-    console.log('\n\nAll tests completed. Closing connection...');
-    ws.close();
-  }, 1500);
-});
+  ws.on('close', () => {
+    console.log('\nDisconnected from MCP server');
+    process.exit(0);
+  });
 
-ws.on('message', (data) => {
-  const message = JSON.parse(data.toString());
-  console.log('\n--- Received response ---');
-  console.log(JSON.stringify(message, null, 2));
-});
+  ws.on('error', (error) => {
+    console.error('WebSocket error:', error.message);
+    process.exit(1);
+  });
+}
 
-ws.on('close', () => {
-  console.log('\nDisconnected from MCP server');
-  process.exit(0);
-});
-
-ws.on('error', (error) => {
-  console.error('WebSocket error:', error.message);
+start().catch(error => {
+  console.error('Failed to start MCP client:', error.message);
   process.exit(1);
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,29 @@
 version: '3.8'
 
 services:
+  auth:
+    build:
+      context: ./auth
+      dockerfile: Dockerfile
+    container_name: mcp-auth
+    environment:
+      - PORT=8080
+      - CLIENT_ID=${OAUTH_CLIENT_ID:-mcp-client}
+      - CLIENT_SECRET=${OAUTH_CLIENT_SECRET:-mcp-client-secret}
+      - ISSUER=http://auth:8080
+      - AUDIENCE=mcp-server
+      - ALLOWED_SCOPES=${OAUTH_ALLOWED_SCOPES:-file.read file.list}
+      - TOKEN_TTL=${OAUTH_TOKEN_TTL:-300}
+    networks:
+      - mcp-network
+
   mcp:
     build:
       context: ./server
       dockerfile: Dockerfile
     container_name: mcp
+    depends_on:
+      - auth
     ports:
       - "3000:3000"
     volumes:
@@ -14,7 +32,10 @@ services:
     environment:
       - TARGET_DIR=/data
       - PORT=3000
-      - API_KEY=${API_KEY:-your-secret-api-key-here}
+      - OAUTH_JWKS_URL=http://auth:8080/jwks.json
+      - OAUTH_ISSUER=http://auth:8080
+      - OAUTH_AUDIENCE=mcp-server
+      - OAUTH_REQUIRED_SCOPES=${OAUTH_REQUIRED_SCOPES:-file.read file.list}
     networks:
       - mcp-network
 
@@ -25,11 +46,15 @@ services:
     container_name: mcp-client
     depends_on:
       - mcp
+      - auth
     volumes:
       - ./client:/app
     environment:
       - SERVER_URL=ws://mcp:3000
-      - API_KEY=${API_KEY:-your-secret-api-key-here}
+      - OAUTH_TOKEN_URL=http://auth:8080/token
+      - OAUTH_CLIENT_ID=${OAUTH_CLIENT_ID:-mcp-client}
+      - OAUTH_CLIENT_SECRET=${OAUTH_CLIENT_SECRET:-mcp-client-secret}
+      - OAUTH_SCOPE=${OAUTH_SCOPE:-file.read file.list}
     networks:
       - mcp-network
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,7 +8,17 @@
       "name": "mcp-server",
       "version": "1.0.0",
       "dependencies": {
+        "jose": "^5.3.0",
         "ws": "^8.18.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/ws": {

--- a/server/package.json
+++ b/server/package.json
@@ -8,6 +8,7 @@
     "start": "node server.js"
   },
   "dependencies": {
+    "jose": "^5.3.0",
     "ws": "^8.18.0"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test"
   },
   "dependencies": {
     "jose": "^5.3.0",

--- a/server/tests/server.test.js
+++ b/server/tests/server.test.js
@@ -1,0 +1,271 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import net from 'node:net';
+import http from 'node:http';
+import { WebSocket } from 'ws';
+import { generateKeyPair, exportJWK, SignJWT } from 'jose';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const serverDir = path.resolve(__dirname, '..');
+
+let jwksServer;
+let jwksPort;
+let privateKey;
+let mcpProcess;
+let serverPort;
+
+const REQUIRED_SCOPES = 'file.read file.list';
+const KEY_ID = 'test-key';
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+    server.on('error', reject);
+  });
+}
+
+async function startJwksServer() {
+  const { publicKey, privateKey: signer } = await generateKeyPair('RS256', { modulusLength: 2048 });
+  privateKey = signer;
+  const jwk = await exportJWK(publicKey);
+  jwk.kid = KEY_ID;
+  jwk.use = 'sig';
+  jwk.alg = 'RS256';
+
+  jwksServer = http.createServer((req, res) => {
+    if (req.url === '/jwks.json') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ keys: [jwk] }));
+      return;
+    }
+
+    res.writeHead(404);
+    res.end();
+  });
+
+  jwksPort = await new Promise((resolve, reject) => {
+    jwksServer.listen(0, () => {
+      const address = jwksServer.address();
+      resolve(address.port);
+    });
+    jwksServer.on('error', reject);
+  });
+}
+
+function stopJwksServer() {
+  if (!jwksServer) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    jwksServer.close(() => {
+      jwksServer = undefined;
+      resolve();
+    });
+  });
+}
+
+async function waitForOutput(proc, matcher, description) {
+  let buffer = '';
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(
+          `Timed out waiting for ${description}. Output so far:\n${buffer}`
+        )
+      );
+    }, 8000);
+
+    const onData = (chunk) => {
+      buffer += chunk.toString();
+      if (matcher.test(buffer)) {
+        cleanup();
+        resolve();
+      }
+    };
+
+    const onExit = (code) => {
+      cleanup();
+      reject(
+        new Error(
+          `${description} process exited early` + (code !== null ? ` (code ${code})` : '')
+        )
+      );
+    };
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      proc.stdout?.off('data', onData);
+      proc.stderr?.off('data', onData);
+      proc.off('exit', onExit);
+    };
+
+    proc.on('exit', onExit);
+    proc.stdout?.on('data', onData);
+    proc.stderr?.on('data', onData);
+  });
+}
+
+async function startMcpServer() {
+  serverPort = await getFreePort();
+  mcpProcess = spawn(
+    process.execPath,
+    ['server.js'],
+    {
+      cwd: serverDir,
+      env: {
+        ...process.env,
+        PORT: String(serverPort),
+        TARGET_DIR: path.resolve(serverDir, '..', 'data'),
+        OAUTH_JWKS_URL: `http://localhost:${jwksPort}/jwks.json`,
+        OAUTH_ISSUER: `http://localhost:${jwksPort}`,
+        OAUTH_AUDIENCE: 'mcp-server',
+        OAUTH_REQUIRED_SCOPES: REQUIRED_SCOPES
+      },
+      stdio: ['ignore', 'pipe', 'pipe']
+    }
+  );
+
+  await waitForOutput(mcpProcess, /MCP Server listening on port/i, 'MCP server');
+}
+
+async function stopMcpServer() {
+  if (!mcpProcess) {
+    return;
+  }
+  mcpProcess.kill('SIGTERM');
+  await once(mcpProcess, 'exit').catch(() => {});
+  mcpProcess = undefined;
+}
+
+function createAccessToken(scope = REQUIRED_SCOPES) {
+  return new SignJWT({ scope })
+    .setProtectedHeader({ alg: 'RS256', kid: KEY_ID })
+    .setIssuer(`http://localhost:${jwksPort}`)
+    .setAudience('mcp-server')
+    .setSubject('test-client')
+    .setIssuedAt()
+    .setExpirationTime('2m')
+    .sign(privateKey);
+}
+
+function openWebSocket(headers = {}) {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(`ws://localhost:${serverPort}`, { headers });
+
+    const timeout = setTimeout(() => {
+      cleanup();
+      socket.terminate();
+      reject(new Error('Timed out waiting for WebSocket connection'));
+    }, 5000);
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      socket.off('open', onOpen);
+      socket.off('error', onError);
+    };
+
+    const onOpen = () => {
+      cleanup();
+      resolve(socket);
+    };
+
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+
+    socket.once('open', onOpen);
+    socket.once('error', onError);
+  });
+}
+
+test.before(async () => {
+  await startJwksServer();
+  await startMcpServer();
+});
+
+test.after(async () => {
+  await stopMcpServer();
+  await stopJwksServer();
+});
+
+test('MCP server enforces OAuth 2.1 authentication', async (t) => {
+  await t.test('accepts valid access token and responds to initialize', async () => {
+    const token = await createAccessToken();
+    const ws = await openWebSocket({
+      Authorization: `Bearer ${token}`
+    });
+
+    ws.send(JSON.stringify({ type: 'initialize' }));
+
+    const message = await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        cleanup();
+        reject(new Error('Timed out waiting for initialized response'));
+      }, 3000);
+
+      const onMessage = (data) => {
+        cleanup();
+        resolve(data.toString());
+      };
+
+      const onError = (error) => {
+        cleanup();
+        reject(error);
+      };
+
+      const cleanup = () => {
+        clearTimeout(timer);
+        ws.off('message', onMessage);
+        ws.off('error', onError);
+      };
+
+      ws.once('message', onMessage);
+      ws.once('error', onError);
+    });
+
+    const payload = JSON.parse(message);
+    assert.strictEqual(payload.type, 'initialized');
+    assert.strictEqual(payload.serverInfo?.name, 'file-operations-mcp');
+
+    ws.close();
+    await once(ws, 'close');
+  });
+
+  await t.test('rejects missing bearer token', async () => {
+    await assert.rejects(
+      openWebSocket(),
+      /Unexpected server response: 401/
+    );
+  });
+
+  await t.test('rejects token missing required scopes', async () => {
+    const token = await createAccessToken('file.read'); // missing file.list
+    await assert.rejects(
+      openWebSocket({
+        Authorization: `Bearer ${token}`
+      }),
+      /Unexpected server response: 401/
+    );
+  });
+
+  await t.test('rejects invalid bearer token', async () => {
+    await assert.rejects(
+      openWebSocket({
+        Authorization: 'Bearer invalid-token'
+      }),
+      /Unexpected server response: 401/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add an OAuth 2.1 authorization service that issues JWT access tokens and publishes JWKS metadata
- update the MCP server to verify Bearer tokens (issuer, audience, scopes) instead of API keys
- move the client to client-credentials token retrieval and refresh the docs/docker-compose configuration

## Testing
- not run (environment not available in this session)
