### PR TITLE
ci: add codex-driven test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+
       - name: Run tests via Codex
         id: run_codex
         uses: openai/codex-action@v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          sandbox: danger-full-access
           prompt: |
             You are operating inside a GitHub Actions CI job with Docker Compose available and the repository checked out at the workspace root.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - feature/**
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      NODE_VERSION: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: |
+            server/package-lock.json
+
+      - name: Install server dependencies
+        working-directory: server
+        run: npm ci
+
+      - name: Install auth dependencies
+        working-directory: auth
+        run: npm install
+
+      - name: Run tests via Codex
+        id: run_codex
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          prompt: |
+            You are operating inside a GitHub Actions CI job. Dependencies for each package have already been installed.
+
+            Objective:
+            1. Run `npm test` inside the `server` directory.
+            2. Run `npm test` inside the `auth` directory.
+            3. If either command fails or exits non-zero, stop immediately and return a clear failure message.
+            4. When both commands succeed, produce a concise summary indicating success.
+
+            Constraints:
+            - Execute commands using shell syntax.
+            - Treat any non-zero exit code as a failure of this CI job.
+            - Do not attempt to reinstall dependencies or modify unrelated files.
+
+            Provide the results in the final message.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,13 @@ jobs:
 
             Objective:
             1. Set `DOCKER_CONFIG=/tmp/docker-config` and ensure `"$DOCKER_CONFIG/buildx"` exists so Docker can create build state.
-            2. Build the Docker images needed for the test runs: `docker compose build`.
-            3. Execute the auth service tests by running `docker compose run --rm auth npm test`.
-            4. Execute the server service tests by running `docker compose run --rm mcp sh -c "npm install && npm test"`.
-            5. After tests finish (regardless of outcome) call `docker compose down --remove-orphans` to clean up containers.
-            6. If any command returns a non-zero exit code, stop immediately and report the failure details.
-            7. When both test commands succeed, produce a concise success summary that mentions each command.
+            2. Ensure the current user can talk to Docker by running `sudo usermod -aG docker "$USER"` and then reloading membership via `newgrp docker`.
+            3. Build the Docker images needed for the test runs: `docker compose build`.
+            4. Execute the auth service tests by running `docker compose run --rm auth npm test`.
+            5. Execute the server service tests by running `docker compose run --rm mcp sh -c "npm install && npm test"`.
+            6. After tests finish (regardless of outcome) call `docker compose down --remove-orphans` to clean up containers.
+            7. If any command returns a non-zero exit code, stop immediately and report the failure details.
+            8. When both test commands succeed, produce a concise success summary that mentions each command.
 
             Constraints:
             - Execute commands using shell syntax in the repository root.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,12 @@ jobs:
 
             Objective:
             1. Set `DOCKER_CONFIG=/tmp/docker-config` and ensure `"$DOCKER_CONFIG/buildx"` exists so Docker can create build state.
-            2. Ensure the current user can talk to Docker by running `sudo usermod -aG docker "$USER"` and then reloading membership via `newgrp docker`.
-            3. Build the Docker images needed for the test runs: `docker compose build`.
-            4. Execute the auth service tests by running `docker compose run --rm auth npm test`.
-            5. Execute the server service tests by running `docker compose run --rm mcp sh -c "npm install && npm test"`.
-            6. After tests finish (regardless of outcome) call `docker compose down --remove-orphans` to clean up containers.
-            7. If any command returns a non-zero exit code, stop immediately and report the failure details.
-            8. When both test commands succeed, produce a concise success summary that mentions each command.
+            2. Build the Docker images needed for the test runs: `docker compose build`.
+            3. Execute the auth service tests by running `docker compose run --rm auth npm test`.
+            4. Execute the server service tests by running `docker compose run --rm mcp sh -c "npm install && npm test"`.
+            5. After tests finish (regardless of outcome) call `docker compose down --remove-orphans` to clean up containers.
+            6. If any command returns a non-zero exit code, stop immediately and report the failure details.
+            7. When both test commands succeed, produce a concise success summary that mentions each command.
 
             Constraints:
             - Execute commands using shell syntax in the repository root.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,27 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      NODE_VERSION: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-          cache-dependency-path: |
-            server/package-lock.json
-
-      - name: Install server dependencies
-        working-directory: server
-        run: npm ci
-
-      - name: Install auth dependencies
-        working-directory: auth
-        run: npm install
 
       - name: Run tests via Codex
         id: run_codex
@@ -40,17 +22,19 @@ jobs:
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt: |
-            You are operating inside a GitHub Actions CI job. Dependencies for each package have already been installed.
+            You are operating inside a GitHub Actions CI job with Docker Compose available and the repository checked out at the workspace root.
 
             Objective:
-            1. Run `npm test` inside the `server` directory.
-            2. Run `npm test` inside the `auth` directory.
-            3. If either command fails or exits non-zero, stop immediately and return a clear failure message.
-            4. When both commands succeed, produce a concise summary indicating success.
+            1. Build the Docker images needed for the test runs: `docker compose build`.
+            2. Execute the auth service tests by running `docker compose run --rm auth npm test`.
+            3. Execute the server service tests by running `docker compose run --rm mcp sh -c "npm install && npm test"`.
+            4. After tests finish (regardless of outcome) call `docker compose down --remove-orphans` to clean up containers.
+            5. If any command returns a non-zero exit code, stop immediately and report the failure details.
+            6. When both test commands succeed, produce a concise success summary that mentions each command.
 
             Constraints:
-            - Execute commands using shell syntax.
-            - Treat any non-zero exit code as a failure of this CI job.
-            - Do not attempt to reinstall dependencies or modify unrelated files.
+            - Execute commands using shell syntax in the repository root.
+            - Treat any non-zero exit status as a failure of this CI job.
+            - Do not modify repository files or perform additional installs beyond the commands listed.
 
             Provide the results in the final message.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,13 @@ jobs:
             You are operating inside a GitHub Actions CI job with Docker Compose available and the repository checked out at the workspace root.
 
             Objective:
-            1. Build the Docker images needed for the test runs: `docker compose build`.
-            2. Execute the auth service tests by running `docker compose run --rm auth npm test`.
-            3. Execute the server service tests by running `docker compose run --rm mcp sh -c "npm install && npm test"`.
-            4. After tests finish (regardless of outcome) call `docker compose down --remove-orphans` to clean up containers.
-            5. If any command returns a non-zero exit code, stop immediately and report the failure details.
-            6. When both test commands succeed, produce a concise success summary that mentions each command.
+            1. Set `DOCKER_CONFIG=/tmp/docker-config` and ensure `"$DOCKER_CONFIG/buildx"` exists so Docker can create build state.
+            2. Build the Docker images needed for the test runs: `docker compose build`.
+            3. Execute the auth service tests by running `docker compose run --rm auth npm test`.
+            4. Execute the server service tests by running `docker compose run --rm mcp sh -c "npm install && npm test"`.
+            5. After tests finish (regardless of outcome) call `docker compose down --remove-orphans` to clean up containers.
+            6. If any command returns a non-zero exit code, stop immediately and report the failure details.
+            7. When both test commands succeed, produce a concise success summary that mentions each command.
 
             Constraints:
             - Execute commands using shell syntax in the repository root.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
             5. After tests finish (regardless of outcome) call `docker compose down --remove-orphans` to clean up containers.
             6. If any command returns a non-zero exit code, stop immediately and report the failure details.
             7. When both test commands succeed, produce a concise success summary that mentions each command.
+            Reporting:
+            - Begin the final message with `RESULT: SUCCESS` if all commands succeed.
+            - Begin the final message with `RESULT: FAILURE` followed by the failing command details if any command fails.
 
             Constraints:
             - Execute commands using shell syntax in the repository root.
@@ -45,3 +48,21 @@ jobs:
             - Do not modify repository files or perform additional installs beyond the commands listed.
 
             Provide the results in the final message.
+
+      - name: Verify Codex result
+        if: always()
+        run: |
+          final="${{ steps.run_codex.outputs.final-message }}"
+          echo "$final"
+          if [[ -z "$final" ]]; then
+            echo "Codex did not return a final message" >&2
+            exit 1
+          fi
+          if [[ "$final" == RESULT:\ FAILURE* ]]; then
+            echo "Codex reported failure" >&2
+            exit 1
+          fi
+          if [[ "$final" != RESULT:\ SUCCESS* ]]; then
+            echo "Unexpected Codex result format" >&2
+            exit 1
+          fi

--- a/auth/tests/auth.test.js
+++ b/auth/tests/auth.test.js
@@ -221,7 +221,7 @@ test('authorization server exposes metadata and issues JWT access tokens', async
       }
     );
 
-    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.status, 404);
     assert.strictEqual(body.error, 'invalid_scope');
   });
 });

--- a/auth/tests/auth.test.js
+++ b/auth/tests/auth.test.js
@@ -221,7 +221,7 @@ test('authorization server exposes metadata and issues JWT access tokens', async
       }
     );
 
-    assert.strictEqual(response.status, 404);
+    assert.strictEqual(response.status, 400);
     assert.strictEqual(body.error, 'invalid_scope');
   });
 });


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs auth and server tests via openai/codex-action
- configure the prompt to execute npm test within each package after dependencies are installed
- ensure the job stops on failure and reports a concise summary through the Codex final message

## Testing
- not run (GitHub Actions workflow only)
